### PR TITLE
feat(devnet): add `core` gentx for Noble Core Team

### DIFF
--- a/devnet/core/genesis.json
+++ b/devnet/core/genesis.json
@@ -37,6 +37,13 @@
           "pub_key": null,
           "account_number": "0",
           "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "noble1xynp8wn5r33c6dvhhg3zufn4xghgwz9h75mp06",
+          "pub_key": null,
+          "account_number": "1",
+          "sequence": "0"
         }
       ]
     },
@@ -61,9 +68,22 @@
               "amount": "1000000000000000"
             }
           ]
+        },
+        {
+          "address": "noble1xynp8wn5r33c6dvhhg3zufn4xghgwz9h75mp06",
+          "coins": [
+            {
+              "denom": "ustake",
+              "amount": "1000000"
+            }
+          ]
         }
       ],
       "supply": [
+        {
+          "denom": "ustake",
+          "amount": "1000000"
+        },
         {
           "denom": "uusdc",
           "amount": "1000000000000000"
@@ -208,7 +228,70 @@
       "total_forwarded": {}
     },
     "genutil": {
-      "gen_txs": []
+      "gen_txs": [
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "Noble Core Team",
+                  "identity": "",
+                  "website": "",
+                  "security_contact": "",
+                  "details": ""
+                },
+                "commission": {
+                  "rate": "0.100000000000000000",
+                  "max_rate": "0.200000000000000000",
+                  "max_change_rate": "0.010000000000000000"
+                },
+                "min_self_delegation": "1",
+                "delegator_address": "",
+                "validator_address": "noblevaloper1xynp8wn5r33c6dvhhg3zufn4xghgwz9hsyh3ey",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.ed25519.PubKey",
+                  "key": "jDdw9wltixV3Y39oWUWRIHMpB5TSw6G4yGmTwWCafiY="
+                },
+                "value": {
+                  "denom": "ustake",
+                  "amount": "1000000"
+                }
+              }
+            ],
+            "memo": "f16ed437f98a32700563ac627d3fa36882dd0463@172.31.38.23:26656",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [
+              {
+                "public_key": {
+                  "@type": "/cosmos.crypto.secp256k1.PubKey",
+                  "key": "AjSdkJqtJE4wg1W1If0ZlXu0B87vMX6W/M6H2FzCrZy5"
+                },
+                "mode_info": {
+                  "single": {
+                    "mode": "SIGN_MODE_DIRECT"
+                  }
+                },
+                "sequence": "0"
+              }
+            ],
+            "fee": {
+              "amount": [],
+              "gas_limit": "200000",
+              "payer": "",
+              "granter": ""
+            },
+            "tip": null
+          },
+          "signatures": [
+            "ipXglmcMXR8kqylJcRkhHciZIFTY3hvFGrSZmPsklr1YmhELwJXCxWRxz7jzVL/0vnQrfPyRq8WyCXHdJ2J6AA=="
+          ]
+        }
+      ]
     },
     "globalfee": {
       "gas_prices": [],

--- a/devnet/core/gentx/noble.json
+++ b/devnet/core/gentx/noble.json
@@ -1,0 +1,62 @@
+{
+  "body": {
+    "messages": [
+      {
+        "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+        "description": {
+          "moniker": "Noble Core Team",
+          "identity": "",
+          "website": "",
+          "security_contact": "",
+          "details": ""
+        },
+        "commission": {
+          "rate": "0.100000000000000000",
+          "max_rate": "0.200000000000000000",
+          "max_change_rate": "0.010000000000000000"
+        },
+        "min_self_delegation": "1",
+        "delegator_address": "",
+        "validator_address": "noblevaloper1xynp8wn5r33c6dvhhg3zufn4xghgwz9hsyh3ey",
+        "pubkey": {
+          "@type": "/cosmos.crypto.ed25519.PubKey",
+          "key": "jDdw9wltixV3Y39oWUWRIHMpB5TSw6G4yGmTwWCafiY="
+        },
+        "value": {
+          "denom": "ustake",
+          "amount": "1000000"
+        }
+      }
+    ],
+    "memo": "f16ed437f98a32700563ac627d3fa36882dd0463@172.31.38.23:26656",
+    "timeout_height": "0",
+    "extension_options": [],
+    "non_critical_extension_options": []
+  },
+  "auth_info": {
+    "signer_infos": [
+      {
+        "public_key": {
+          "@type": "/cosmos.crypto.secp256k1.PubKey",
+          "key": "AjSdkJqtJE4wg1W1If0ZlXu0B87vMX6W/M6H2FzCrZy5"
+        },
+        "mode_info": {
+          "single": {
+            "mode": "SIGN_MODE_DIRECT"
+          }
+        },
+        "sequence": "0"
+      }
+    ],
+    "fee": {
+      "amount": [],
+      "gas_limit": "200000",
+      "payer": "",
+      "granter": ""
+    },
+    "tip": null
+  },
+  "signatures": [
+    "ipXglmcMXR8kqylJcRkhHciZIFTY3hvFGrSZmPsklr1YmhELwJXCxWRxz7jzVL/0vnQrfPyRq8WyCXHdJ2J6AA=="
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Devnet now includes a pre-configured “Noble Core Team” validator created at genesis with 1,000,000 ustake self-delegation and standard commission parameters.
- Chores
  - Updated genesis to include the validator’s gentx, a corresponding funded account and balance, and matching supply adjustments to reflect the new stake.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->