### PR TITLE
chore(devnet): `core` regenesis

### DIFF
--- a/devnet/core/genesis.json
+++ b/devnet/core/genesis.json
@@ -1,7 +1,7 @@
 {
   "app_name": "nobled",
   "app_version": "v10.1.1",
-  "genesis_time": "2025-09-15T12:00:00Z",
+  "genesis_time": "2025-09-17T12:00:00Z",
   "chain_id": "duke-1",
   "initial_height": 1,
   "app_hash": null,
@@ -92,6 +92,10 @@
           "address": "noble1ppkf20jef5gsez9asj9kaer77f43e8mh3n89r6",
           "coins": [
             {
+              "denom": "ustake",
+              "amount": "999999995000000"
+            },
+            {
               "denom": "uusdc",
               "amount": "1000000000000000"
             }
@@ -146,7 +150,7 @@
       "supply": [
         {
           "denom": "ustake",
-          "amount": "5000000"
+          "amount": "1000000000000000"
         },
         {
           "denom": "uusdc",
@@ -846,11 +850,11 @@
     "runtime": null,
     "slashing": {
       "params": {
-        "signed_blocks_window": "100",
+        "signed_blocks_window": "42000",
         "min_signed_per_window": "0.500000000000000000",
         "downtime_jail_duration": "600s",
-        "slash_fraction_double_sign": "0.050000000000000000",
-        "slash_fraction_downtime": "0.010000000000000000"
+        "slash_fraction_double_sign": "1.000000000000000000",
+        "slash_fraction_downtime": "0.000000000000000000"
       },
       "signing_infos": [],
       "missed_blocks": []


### PR DESCRIPTION
This PR performs a regenesis of the `duke-1` network, due to a misconfiguration of the `x/slashing` module parameters. It also mints additional $STAKE token supply to the authority account.